### PR TITLE
Debug Changelog Issue

### DIFF
--- a/links/app/components/Change.tsx
+++ b/links/app/components/Change.tsx
@@ -7,15 +7,14 @@ interface ChangeTypes {
   title: string;
   desc: string;
   date: string;
-  iconPath: string;
 }
 
-const Change: React.FC<ChangeTypes> = ({ id, title, desc, date, iconPath }) => {
+const Change: React.FC<ChangeTypes> = ({ id, title, desc, date }) => {
   return (
     <Link href={`/docs/changelog/${id}`} className="block">
       <section className="w-full bg-[#E6CCB2] border-2 border-[#7F5539] flex flex-col p-6 rounded-lg">
         <div className="flex items-center gap-3 mb-3">
-          <Image width={12} height={12} alt={`${title} icon`} src={iconPath} />
+          <Image width={12} height={12} alt={`${title} icon`} src="/logos/input-logo.svg" />
           <h1>{title}</h1>
         </div>
         <p className="text-sm text-[#7F5539]/80 mb-2">{date}</p>

--- a/links/app/docs/changelog/[id]/page.tsx
+++ b/links/app/docs/changelog/[id]/page.tsx
@@ -36,7 +36,7 @@ export default async function ChangelogEntryPage(props: unknown) {
               width={32}
               height={32}
               alt={`${entry.title} icon`}
-              src={entry.iconPath}
+              src="/logos/input-logo.svg"
             />
             <h1 className="text-xl font-semibold">{entry.title}</h1>
           </div>

--- a/links/app/docs/changelog/page.tsx
+++ b/links/app/docs/changelog/page.tsx
@@ -30,7 +30,6 @@ const ChangelogPage = () => {
               title={change.title}
               desc={change.desc}
               date={change.date}
-              iconPath="/logos/input-logo.svg"
             />
           ))
         ) : (


### PR DESCRIPTION
This pull request includes changes to the `links/app/components/Change.tsx`, `links/app/docs/changelog/[id]/page.tsx`, and `links/app/docs/changelog/page.tsx` files to simplify the handling of icons in the changelog components. The most important changes include removing the `iconPath` property from the `ChangeTypes` interface and updating the components to use a default icon path.

Simplification of icon handling:

* [`links/app/components/Change.tsx`](diffhunk://#diff-4bf1975d7e7a996e255170e046a31be51f504fac2b1d82d296e48a5974d835c1L10-R17): Removed the `iconPath` property from the `ChangeTypes` interface and updated the `Change` component to use a default icon path (`/logos/input-logo.svg`).
* `links/app/docs/changelog/[id]/page.tsx`: Updated the `ChangelogEntryPage` component to use the default icon path (`/logos/input-logo.svg`). ([links/app/docs/changelog/[id]/page.tsxL39-R39](diffhunk://#diff-d7287f48c5ec40e0d74ba90c2261f2682d6fbca59d40516a104d6a4027078542L39-R39))
* [`links/app/docs/changelog/page.tsx`](diffhunk://#diff-5235cba464fe0e4cb2ab25ec273e3e4fcb37f441757de900e51830c21acc5349L33): Removed the `iconPath` property from the `ChangelogPage` component.